### PR TITLE
Escaped quotes for password

### DIFF
--- a/R/ropenblas.R
+++ b/R/ropenblas.R
@@ -145,8 +145,9 @@ modern_openblas <- function(x) {
 
 sudo_key <- function(attempt = 3L) {
   test <- function(key_root) {
+    key_root <- gsub('"', '\\"', key_root, fixed = T)
     system(
-      command = glue("echo {key_root} |sudo -S -k id -u"),
+      command = glue('echo "{key_root}" | sudo -S -k id -u'),
       ignore.stderr = TRUE,
       intern = TRUE
     ) %>%


### PR DESCRIPTION
This PR is related to the following issue https://github.com/prdm0/ropenblas/issues/35

The passwords tested, which also pass the test are: 

`()@'"/\#!?_~[]{}|`

`T<3(,Pg*"?Qd7m@Q`

`  ")_`

